### PR TITLE
Adding changes to enable OTA programming

### DIFF
--- a/software/lamp-os/README.md
+++ b/software/lamp-os/README.md
@@ -37,13 +37,51 @@ You can auto format your code by changing the Vscode settings (ctrl + shift + p 
 
  Currently the flash process is a few steps:
 
-* Pioarduino in the VSCode sidebar -> project tasks -> platform -> build filesystem image
-* Pioarduino in the VSCode sidebar -> project tasks -> platform -> upload filesystem image
-* Pioarduino in the VSCode sidebar -> project tasks -> general -> upload
+ If you've got a completely new board, it's prudent to run erase flash to completely clear your device:
+
+* Pioarduino in the VSCode sidebar -> Project Tasks -> Platform -> Erase Flash
+
+To push the web app in the data dir, you can run
+
+* Pioarduino in the VSCode sidebar -> Project Tasks -> Platform -> build filesystem image
+* Pioarduino in the VSCode sidebar -> Project Tasks -> Platform -> upload filesystem image
+
+To upload the factory firmware image:
+
+* Pioarduino in the VSCode sidebar -> Project Tasks -> General -> upload
 
  Note that depending on the board, you may need to hold the boot button in order to flash the board.
 
- ## Distribution
+## Updating the web app for development
 
- While you can program boards through the IDE, Lamp OS intends to be deployed on the web so anyone can format and
- maintain their own firmware
+Plug your lamp board into a usb port
+
+In VSCode, navigate to `Pioarduino > Quick Access > Miscellaneous > pioarduino core CLI`
+
+This will bring up a window in the correct environment to upload
+
+```bash
+cd ../lamp-ui
+npm ci
+npm run build:upload
+```
+
+This process will build a new .spiffs partition and replace it onboard your esp32.
+
+## Distribution
+
+While you can program boards through the IDE, Lamp OS intends to be deployed on the web so anyone can format and maintain their own firmware
+
+## OTA Updating
+
+Join your lamp's wifi and navigate to <http://lamp.local/update> and update the following two files in pairs:
+
+Lamp's main firmware:
+
+* file: firmware.bin
+* OTA Mode: Firmware
+
+Lamp's mobile UI:
+
+* file: spiffs.bin
+* OTA Mode: LittleFS/Spiffs

--- a/software/lamp-os/partitions.csv
+++ b/software/lamp-os/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,data,nvs,0x9000,0x5000,
-otadata,data,ota,0x11000,0x2000,
-app0,app,ota_0,0x20000,0x1E0000,
-app1,app,ota_1,0x200000,0x1E0000,
-spiffs,data,spiffs,0x3E0000,0x20000,
+otadata,data,ota,0xE000,0x2000,
+app0,app,ota_0,0x10000,0x1E0000,
+app1,app,ota_1,0x1F0000,0x1E0000,
+spiffs,data,spiffs,0x3D0000,0x30000,

--- a/software/lamp-os/platformio.ini
+++ b/software/lamp-os/platformio.ini
@@ -1,4 +1,4 @@
-; PioArduino Project Configuration File
+; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags
@@ -7,6 +7,7 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+
 [platformio]
 build_cache_dir = ./.buildcache
 data_dir = ./data
@@ -15,24 +16,25 @@ default_envs = upesy_wroom
 [env:native]
 platform = native
 build_flags =
-    -std=gnu++2a
-    -std=c++2a
+	-std=gnu++2a
+	-std=c++2a
 build_unflags =
-    -fno-rtti
-    -std=gnu++11
+	-fno-rtti
+	-std=gnu++11
 
 [env:upesy_wroom]
 board = upesy_wroom
 lib_ldf_mode = chain
 lib_compat_mode = strict
-platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
 framework = arduino
 lib_deps =
 	adafruit/Adafruit NeoPixel@1.12.3
 	bblanchon/ArduinoJson@7.2.1
 	h2zero/NimBLE-Arduino@2.3.6
-  	ESP32Async/AsyncTCP@3.4.7
+	ESP32Async/AsyncTCP@3.4.7
 	ESP32Async/ESPAsyncWebServer@3.8.0
+	ayushsharma82/ElegantOTA@3.1.7
 
 build_flags =
 	; optimize for performance
@@ -44,6 +46,7 @@ build_flags =
 
 	; Increase radio power for bluetooth. should be modified in tandem with bluetooth.h constants
 	-D MYNEWT_VAL_BLE_LL_TX_PWR_DBM=4
+	-D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
 
 	; Recommended build options from ESPAsyncWebServer
 	-D CONFIG_ASYNC_TCP_MAX_ACK_TIME=5000
@@ -58,7 +61,7 @@ build_flags =
 	-D NDEBUG
 	-D CORE_DEBUG_LEVEL=0
 
-;Over the air partition is disabled for lamps
+; custom partitions for lamps to support ota
 board_build.partitions = ./partitions.csv
 board_build.filesystem = spiffs
 monitor_speed = 115200

--- a/software/lamp-os/src/components/network/wifi.cpp
+++ b/software/lamp-os/src/components/network/wifi.cpp
@@ -6,13 +6,13 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <ESPmDNS.h>
+#include <ElegantOTA.h>
 #include <Preferences.h>
 #include <WiFi.h>
 
 #include "../../config/config.hpp"
 #include "../../util/color.hpp"
 #include "./artnet.hpp"
-#include "./wifi.hpp"
 #include "SPIFFS.h"
 
 namespace lamp {
@@ -37,7 +37,7 @@ void wsMonitor() {
     Serial.printf("Client %" PRIu32 " fragment %" PRIu32 ": %s\n", client->id(),
                   frameInfo->num, (const char *)data);
   });
-}
+};
 #endif
 
 void onWiFiEvent(WiFiEvent_t event) {
@@ -150,7 +150,14 @@ void WifiComponent::begin(Config *inConfig) {
         request->send(500);
         return;
       });
+
   cors.setMethods("POST, PUT, GET, OPTIONS, DELETE");
+  ElegantOTA.begin(&server);
+  ElegantOTA.onEnd([this](bool success) {
+    if (success) {
+      requiresReboot = true;
+    }
+  });
   server.addMiddleware(&cors);
   server.addHandler(&ws);
   server.begin();


### PR DESCRIPTION
This change:
 - Adds examples from ElegantOTA updater 
 - moves the partitions to line up with espressif's "factory" partition at 0x10000
   - be sure to erase the flash of any new board before proceeding
 - expands spiffs partition size slightly to 192k
 - http://lamp.local/update will allow file uploads for firmware.bin and spiffs.bin from the build artifacts.
 - Updated Docs